### PR TITLE
Fix error when not using toolbar

### DIFF
--- a/quill.authorship.js
+++ b/quill.authorship.js
@@ -50,20 +50,21 @@ class Authorship {
       }
     });
     this.addAuthor(this.options.authorId, this.options.color);
-	
-	// for authorship color on/off toolbar item
-	let toolbar = this.quill.getModule('toolbar');
-	toolbar.addHandler('authorship-toggle', function() {
-		
-	});
-	let customButton = document.querySelector('button.ql-authorship-toggle');
-		
-	let authorshipObj = this;
-	customButton.addEventListener('click', function() {
-		// toggle on/off authorship colors
-		authorshipObj.enable(!authorshipObj.isEnabled);		
-	});	
-	
+
+  	// for authorship color on/off toolbar item
+  	let toolbar = this.quill.getModule('toolbar');
+    if(toolbar) {
+    	toolbar.addHandler('authorship-toggle', function() {
+
+    	});
+    	let customButton = document.querySelector('button.ql-authorship-toggle');
+
+    	let authorshipObj = this;
+    	customButton.addEventListener('click', function() {
+    		// toggle on/off authorship colors
+    		authorshipObj.enable(!authorshipObj.isEnabled);
+    	});
+    }
   }
 
   enable(enabled = true) {


### PR DESCRIPTION
If the toolbar module is not configured in the Quill instance this plugin causes an error.

I've attached a PR that fixes this issue.